### PR TITLE
Add support for custom vmod imports

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1109,6 +1109,7 @@ The following parameters are available in the `varnish::vcl` class:
 * [`unset_headers`](#-varnish--vcl--unset_headers)
 * [`unset_headers_debugips`](#-varnish--vcl--unset_headers_debugips)
 * [`vcl_version`](#-varnish--vcl--vcl_version)
+* [`import_vmods`](#-varnish--vcl--import_vmods)
 
 ##### <a name="-varnish--vcl--functions"></a>`functions`
 
@@ -1350,6 +1351,14 @@ Data type: `Varnish::Vclversion`
 Which version von VCL should be used
 
 Default value: `'4'`
+
+##### <a name="-varnish--vcl--import_vmods"></a>`import_vmods`
+
+Data type: `Optional[Array]`
+
+List of vmods that should be imported
+
+Default value: `undef`
 
 ## Defined types
 

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -72,6 +72,8 @@
 #   Do not unset the named headers for the following IP's
 # @param vcl_version
 #   Which version von VCL should be used
+# @param import_vmods
+#   List of vmods that should be imported
 #
 # @note
 #   VCL applies following restictions:
@@ -112,6 +114,7 @@ class varnish::vcl (
   Array[String] $unset_headers     = ['Via','X-Powered-By','X-Varnish','Server','Age','X-Cache'],
   Array[Stdlib::IP::Address] $unset_headers_debugips = ['172.0.0.1'],
   Varnish::Vclversion $vcl_version     = '4',
+  Optional[Array] $import_vmods = undef,
 ) {
   include varnish
 

--- a/templates/varnish4-vcl.erb
+++ b/templates/varnish4-vcl.erb
@@ -3,6 +3,11 @@
 vcl 4.0;
 import std;
 import directors;
+<%- if @import_vmods -%>
+<%- @import_vmods.each do |vmod| -%>
+import <%= vmod %>;
+<%- end -%>
+<%- end -%>
 
 #Import file with probe definitions
 include "includes/probes.vcl";


### PR DESCRIPTION
This adds varnish::vcl::import_vmods class parameter that allows the user to specify an array of custom vmods that should be imported to the VCL.